### PR TITLE
헤더 관련 패딩 및 레이아웃 수정

### DIFF
--- a/src/components/AddButton.tsx
+++ b/src/components/AddButton.tsx
@@ -7,7 +7,7 @@ const ButtonWrapper = styled.div`
   position: absolute;
   height: 72px;
   bottom: 0;
-  right: -0.5px;
+  right: 0;
 `;
 
 const AddButton: FC = () => {

--- a/src/components/Story.tsx
+++ b/src/components/Story.tsx
@@ -42,7 +42,7 @@ const StoryWrapper = styled.div<{ position: string }>`
   width: 220px;
   height: 282px;
   margin: ${(props) =>
-    props.position === 'left' ? '0 auto 60px 24px' : '0 24px 60px auto'};
+    props.position === 'left' ? '0 auto 60px 0' : '0 0 60px auto'};
   padding: 12px;
   border: 1px solid ${(props) => props.theme.colors.darkbrown};
   background-color: ${(props) => props.theme.colors.white};

--- a/src/pages/AddStory.tsx
+++ b/src/pages/AddStory.tsx
@@ -1,4 +1,5 @@
 import React, { FC } from 'react';
+import Layout from '@/components/Layout';
 import styled from 'styled-components';
 import HEADER_TYPES from '@/types/HeaderTypes';
 import TitleInput from '@/components/TitleInput';
@@ -17,7 +18,7 @@ const AddContent: FC = () => {
   const { nation } = useAddContent();
 
   return (
-    <>
+    <Layout>
       <Switch>
         <Route exact path={path}>
           <AddContentWrapper>
@@ -36,12 +37,12 @@ const AddContent: FC = () => {
           <NationSearch />
         </Route>
       </Switch>
-    </>
+    </Layout>
   );
 };
 
 const AddContentWrapper = styled.div`
-  padding: 0 24px;
+  // padding: 0 24px;
 `;
 
 export default AddContent;

--- a/src/pages/Album.tsx
+++ b/src/pages/Album.tsx
@@ -17,7 +17,7 @@ const Album: FC = () => {
   const isEmptyAlbum = useMemo(() => albumData.length === 0, [albumData]);
 
   return (
-    <Layout padding={'0 24px'}>
+    <Layout>
       <Header type={HEADER_TYPES.ALBUM} />
 
       {isEmptyAlbum && (

--- a/src/pages/Header.tsx
+++ b/src/pages/Header.tsx
@@ -140,7 +140,7 @@ const Header: FC<Props> = ({
       {type === HEADER_TYPES.ALBUM && (
         <>
           <Icon>
-            <Link to="/feed">
+            <Link to="/">
               <FeatureIcon name={'feed'} />
             </Link>
           </Icon>

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -1,4 +1,5 @@
 import React, { FC, useEffect, useState } from 'react';
+import Layout from '@/components/Layout';
 import Story from '@/components/Story';
 import AddButton from '@/components/AddButton';
 import HEADER_TYPES from '@/types/HeaderTypes';
@@ -21,7 +22,7 @@ const Main: FC = () => {
   }, []);
 
   return (
-    <>
+    <Layout>
       <Header type={HEADER_TYPES.FEED} />
       {storyList.map((story, idx) => {
         const { id } = story;
@@ -29,7 +30,7 @@ const Main: FC = () => {
         return <Story key={id} position={pos} {...story} />;
       })}
       <AddButton />
-    </>
+    </Layout>
   );
 };
 


### PR DESCRIPTION
## PR 설명
> 커밋한 내용에 대해 설명해주세요

- 샛별님이 올려주신 이슈 보고 `<Layout>` 태그로 한번 감싸줬습니다~ 기존 padding이랑 겹쳐서 `Layout`에서 공통으로 적용된 디자인은 주석 처리해뒀어요 
- 관련 자세한 내용입니다: 
  - `Main.tsx`: `<Layout>` 태그로 감싸줘서 모든 페이지에 공통으로 기본 패딩 들어가게 세팅해뒀습니다 
  - `Album.tsx`: `Header`를 만들 때 `Layout`의 패딩을 고려해서 만든 거였기 때문에 옵셔널로 들어간 0, 24는 제외했습니다 
  - `AddStory.tsx`: `Main.tsx`와 마찬가지로 `<Layout>` 태그로 감싸줬고, 같은 효과를 주는 `AddContentWrapper`의 스타일은 주석처리 해뒀습니다 
  - `Story.tsx`: `Main.tsx`의 `<Layout>` 때문에 `Story` 컴포넌트에 24px margin이 필요없어서 0으로 변경했습니다 


## 확인해야 할 부분

- [ ] 모든 페이지에 헤더가 동일한 선에 있는지 

## 참고자료
> 참고자료가 있다면 추가해주세요

close #38 
