### PR TITLE
헤더 경로 변경

### DIFF
--- a/src/atoms/myPageState.ts
+++ b/src/atoms/myPageState.ts
@@ -1,0 +1,17 @@
+import { atom } from 'recoil';
+
+export enum MyPageStateField {
+  FEED = 'FEED',
+  ALBUM = 'ALBUM',
+}
+
+interface IMyPageStateAtom {
+  parent: MyPageStateField;
+}
+
+export const MyPageStateAtom = atom<IMyPageStateAtom>({
+  key: 'myPageState',
+  default: {
+    parent: MyPageStateField.FEED,
+  },
+});

--- a/src/pages/Header.tsx
+++ b/src/pages/Header.tsx
@@ -1,8 +1,190 @@
-import React, { FC } from 'react';
+import React, { FC, useCallback } from 'react';
 import HEADER_TYPES from '@/types/HeaderTypes';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import FeatureIcon from '@/components/FeatureIcon';
+import { MyPageStateAtom, MyPageStateField } from '@/atoms/myPageState';
+import { useSetRecoilState } from 'recoil';
+
+interface ArrowProps {
+  route: string;
+}
+
+const Arrow: FC<ArrowProps> = ({ route }) => {
+  return (
+    <Icon>
+      <Link to={route}>
+        <FeatureIcon name={'arrow'} />
+      </Link>
+    </Icon>
+  );
+};
+
+interface MyPageProps {
+  updateParent: (parent: MyPageStateField) => void;
+  parent: MyPageStateField;
+}
+
+const MyPage: FC<MyPageProps> = ({ updateParent, parent }) => {
+  const handleClick = () => {
+    updateParent(parent);
+  };
+
+  return (
+    <Icon
+      onClick={handleClick}
+      onKeyPress={handleClick}
+      role="button"
+      tabIndex={0}
+    >
+      <Link to={'/myPage'}>
+        <FeatureIcon name={'mypage'} />
+      </Link>
+    </Icon>
+  );
+};
+
+interface Props {
+  type: HEADER_TYPES;
+  completed?: boolean;
+  primaryFunction?: () => void;
+  deleteFunction?: () => void;
+  parentRoute?: MyPageStateField;
+}
+
+const Header: FC<Props> = ({
+  type,
+  completed = true,
+  primaryFunction = () => {},
+  deleteFunction = () => {},
+  parentRoute = MyPageStateField.FEED,
+}) => {
+  const setMyPageState = useSetRecoilState(MyPageStateAtom);
+
+  const updateMyPageParent = useCallback(
+    (parent: MyPageStateField) => {
+      setMyPageState((prevState) => ({
+        ...prevState,
+        parent,
+      }));
+    },
+    [setMyPageState]
+  );
+
+  return (
+    <StyledHeader>
+      {type === HEADER_TYPES.FEED && (
+        <>
+          <Icon>
+            <Link to="/album">
+              <FeatureIcon name={'album'} />
+            </Link>
+          </Icon>
+          <div>
+            <Icon>
+              <div
+                onClick={primaryFunction}
+                onKeyPress={primaryFunction}
+                role="button"
+                tabIndex={0}
+              >
+                <FeatureIcon name={'save'} />
+              </div>
+            </Icon>
+            <MyPage
+              updateParent={updateMyPageParent}
+              parent={MyPageStateField.FEED}
+            />
+          </div>
+        </>
+      )}
+
+      {type === HEADER_TYPES.ADD_EDIT && (
+        <>
+          <Arrow route={'/'} />
+          {completed ? (
+            <Text
+              completed={completed}
+              onClick={primaryFunction}
+              onKeyPress={primaryFunction}
+              role="button"
+              tabIndex={0}
+            >
+              완료
+            </Text>
+          ) : (
+            <Text completed={completed}>완료</Text>
+          )}
+        </>
+      )}
+
+      {type === HEADER_TYPES.DETAIL && (
+        <>
+          <Arrow route={'/'} />
+          <div>
+            <Text
+              onClick={primaryFunction}
+              onKeyPress={primaryFunction}
+              role="button"
+              tabIndex={0}
+            >
+              수정
+            </Text>
+            <Text
+              onClick={deleteFunction}
+              onKeyPress={deleteFunction}
+              role="button"
+              tabIndex={0}
+            >
+              삭제
+            </Text>
+          </div>
+        </>
+      )}
+
+      {type === HEADER_TYPES.ALBUM && (
+        <>
+          <Icon>
+            <Link to="/">
+              <FeatureIcon name={'feed'} />
+            </Link>
+          </Icon>
+          <MyPage
+            updateParent={updateMyPageParent}
+            parent={MyPageStateField.ALBUM}
+          />
+        </>
+      )}
+
+      {type === HEADER_TYPES.MY_PAGE && (
+        <Icon>
+          <Link to={parentRoute === MyPageStateField.ALBUM ? '/album' : '/'}>
+            <FeatureIcon name={'arrow'} />
+          </Link>
+        </Icon>
+      )}
+
+      {type === HEADER_TYPES.MY_PAGE_EDIT && (
+        <>
+          <Arrow route={'/myPage'} />
+          {completed ? (
+            <Text
+              completed={completed}
+              onClick={primaryFunction}
+              onKeyPress={primaryFunction}
+              role="button"
+              tabIndex={0}
+            >
+              완료
+            </Text>
+          ) : (
+            <Text completed={completed}>완료</Text>
+          )}
+        </>
+      )}
+    </StyledHeader>
+  );
+};
 
 const StyledHeader = styled.header`
   display: flex;
@@ -35,145 +217,5 @@ const Text = styled.p<{ completed?: boolean }>`
     margin-left: 24px;
   }
 `;
-
-const Arrow = () => {
-  return (
-    <Icon>
-      <Link to="/">
-        <FeatureIcon name={'arrow'} />
-      </Link>
-    </Icon>
-  );
-};
-
-const MyPage = () => {
-  return (
-    <Icon>
-      <Link to="/myPage">
-        <FeatureIcon name={'mypage'} />
-      </Link>
-    </Icon>
-  );
-};
-
-interface Props {
-  type: HEADER_TYPES;
-  completed?: boolean;
-  primaryFunction?: () => void;
-  deleteFunction?: () => void;
-}
-
-const Header: FC<Props> = ({
-  type,
-  completed = true,
-  primaryFunction = () => {},
-  deleteFunction = () => {},
-}) => {
-  return (
-    <StyledHeader>
-      {type === HEADER_TYPES.FEED && (
-        <>
-          <Icon>
-            <Link to="/album">
-              <FeatureIcon name={'album'} />
-            </Link>
-          </Icon>
-          <div>
-            <Icon>
-              <div
-                onClick={primaryFunction}
-                onKeyPress={primaryFunction}
-                role="button"
-                tabIndex={0}
-              >
-                <FeatureIcon name={'save'} />
-              </div>
-            </Icon>
-            <MyPage />
-          </div>
-        </>
-      )}
-
-      {type === HEADER_TYPES.ADD_EDIT && (
-        <>
-          <Arrow />
-          {completed ? (
-            <Text
-              completed={completed}
-              onClick={primaryFunction}
-              onKeyPress={primaryFunction}
-              role="button"
-              tabIndex={0}
-            >
-              완료
-            </Text>
-          ) : (
-            <Text completed={completed}>완료</Text>
-          )}
-        </>
-      )}
-
-      {type === HEADER_TYPES.DETAIL && (
-        <>
-          <Arrow />
-          <div>
-            <Text
-              onClick={primaryFunction}
-              onKeyPress={primaryFunction}
-              role="button"
-              tabIndex={0}
-            >
-              수정
-            </Text>
-            <Text
-              onClick={deleteFunction}
-              onKeyPress={deleteFunction}
-              role="button"
-              tabIndex={0}
-            >
-              삭제
-            </Text>
-          </div>
-        </>
-      )}
-
-      {type === HEADER_TYPES.ALBUM && (
-        <>
-          <Icon>
-            <Link to="/">
-              <FeatureIcon name={'feed'} />
-            </Link>
-          </Icon>
-          <MyPage />
-        </>
-      )}
-
-      {type === HEADER_TYPES.MY_PAGE && <Arrow />}
-
-      {type === HEADER_TYPES.MY_PAGE_EDIT && (
-        <>
-          <Icon>
-            <Link to="/myPage">
-              <FeatureIcon name={'arrow'} />
-            </Link>
-          </Icon>
-          {completed ? (
-            <Text
-              completed={completed}
-              onClick={primaryFunction}
-              onKeyPress={primaryFunction}
-              role="button"
-              tabIndex={0}
-            >
-              완료
-            </Text>
-          ) : (
-            <Text completed={completed}>완료</Text>
-          )}
-        </>
-      )}
-    </StyledHeader>
-  );
-};
 
 export default Header;

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -5,6 +5,8 @@ import styled from 'styled-components';
 import { UsernameRow, AccountRow, ActionRow } from '@/components/MyPage';
 import LOGIN_TYPES from '@/types/LoginTypes';
 import LeaveModal from '@/components/MyPage/LeaveModal';
+import { MyPageStateAtom } from '@/atoms/myPageState';
+import { useRecoilValue } from 'recoil';
 import Header from './Header';
 
 // TODO: /users 경로로 이름 + 소셜 정보 가져오기
@@ -13,6 +15,8 @@ const socialState = LOGIN_TYPES.KAKAO;
 
 const MyPage: FC = () => {
   const [showLeaveModal, setShowLeaveModal] = useState(false);
+
+  const { parent } = useRecoilValue(MyPageStateAtom);
 
   const handleModalClose = () => {
     setShowLeaveModal(false);
@@ -24,7 +28,7 @@ const MyPage: FC = () => {
 
   return (
     <Layout>
-      <Header type={HEADER_TYPES.MY_PAGE} />
+      <Header type={HEADER_TYPES.MY_PAGE} parentRoute={parent} />
       <MyPageContainer>
         <UsernameRow username={usernameState} />
         <AccountRow social={socialState} />


### PR DESCRIPTION
## PR 설명
> 커밋한 내용에 대해 설명해주세요

- 기존 헤더: Back (화살표) 버튼을 누르면 홈피드로 갑니다 
- 수정 헤더: Back (화살표) 버튼을 누르면 제일 마지막 화면으로 이동합니다 (홈피드 혹은 앨범)
  - 마이페이지 내 이동은 "제일 마지막 화면"에서 제외했습니다 
  - history.goBack()을 사용하려다가, 마이페이지에서 이름 수정을 하게되면 다시 이름 수정 페이지로 돌아가게 되는 무한루프가 생겨서 리코일에 아톰 하나 생성했습니다~ 

## 확인해야 할 부분

- [ ] 페이지 이동에 문제 없는지! 

## 참고자료
> 참고자료가 있다면 추가해주세요

close #48 
